### PR TITLE
Show the "edit children" link when all children are disabled

### DIFF
--- a/src/MenuFormController.php
+++ b/src/MenuFormController.php
@@ -214,7 +214,7 @@ class MenuFormController extends DefaultMenuFormController {
 
         $mlid = (int)$links[$id]['#item']->link->getMetaData()['entity_id'];
 
-        if ($form['links'][$id]['#item']->hasChildren) {
+        if ($form['links'][$id]['#item']->hasChildren || $this->menuLinkHasChildren($links[$id]['#item'])) {
           if (is_null($menu_link) || (isset($menu_link) && $menu_link->id() != $mlid)) {
             $form['links'][$id]['title'][] = array(
               '#type' => 'big_menu_button',
@@ -246,6 +246,24 @@ class MenuFormController extends DefaultMenuFormController {
         }
       }
     }
+  }
+
+  /**
+   * Check if the Element has any children, enabled and disabled.
+   *
+   * @param \Drupal\Core\Menu\MenuLinkTreeElement $element
+   *   The parent element.
+   *
+   * @return bool
+   */
+  protected function menuLinkHasChildren(MenuLinkTreeElement $element) {
+    $depth = $element->depth + 1;
+    $tree_params = new MenuTreeParameters();
+    $tree_params->setMinDepth($depth);
+    $tree_params->setMaxDepth($depth);
+    $tree_params->addExpandedParents([$element->link->getPluginId()]);
+    $tree = $this->menuTree->load($this->entity->id(), $tree_params);
+    return !empty($tree);
   }
 
   /**

--- a/src/MenuFormLinkController.php
+++ b/src/MenuFormLinkController.php
@@ -105,7 +105,7 @@ class MenuFormLinkController extends MenuFormController {
 
         $form['links'][$id]['root'][] = array();
 
-        if ($form['links'][$id]['#item']->hasChildren) {
+        if ($form['links'][$id]['#item']->hasChildren || $this->menuLinkHasChildren($element['#item'])) {
           if (is_null($menu_link) || (isset($menu_link) && $menu_link != $element['#item']->link->getPluginId())) {
             $uri = Url::fromRoute('bigmenu.menu_link', array(
               'menu' => $this->entity->id(),


### PR DESCRIPTION
When all children of a menu link are disabled, the "edit children" link is not shown, as it depends on the has_children flag in the menu tree. The has_children flag is only set to true if the menu link has enabled children. This patch adds an extra check to also show the "edit children" link when all child links are disabled.